### PR TITLE
🐛 Fix chrome for testing download path

### DIFF
--- a/lib/launchers/chrome.js
+++ b/lib/launchers/chrome.js
@@ -28,7 +28,7 @@ export const chrome = createBrowserLauncher({
   ),
 
   downloadUrl: async ({ revision, platform }) => (
-    'https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/' +
+    'https://storage.googleapis.com/chrome-for-testing-public/' +
     `${channels.includes(revision) ? await getLatestRevision(revision) : revision}/` + {
       linux: 'linux64/chrome-linux64.zip',
       darwin: 'mac-x64/chrome-mac-x64.zip',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moonshiner",
-  "version": "0.13.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moonshiner",
-      "version": "0.13.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",


### PR DESCRIPTION
## What is this?

The download path for chrome for testing has changed, so this updates that. 

I know in a future PR we'll want to use the json endpoint that gives revisions & download URLs but for now, this will unbreak a few repos. 